### PR TITLE
restore old behavior: resolve DEFAULT_COMMAND

### DIFF
--- a/packages/airgram/src/components/TdJsonClient.ts
+++ b/packages/airgram/src/components/TdJsonClient.ts
@@ -62,7 +62,7 @@ export class TdJsonClient {
       throw error
     }
     this.client = ffi.Library(
-      command ? resolvePath(command) : DEFAULT_COMMAND,
+      command ? resolvePath(command) : resolvePath(DEFAULT_COMMAND),
       {
         td_create_client_id: ['int', []],
         td_send: ['void', ['int', 'string']],


### PR DESCRIPTION
If you did not specify "command" in older versions, it was assumed that "DEFAULT_COMMAND"
was in the main directory and an attempt was made to resolve the path.